### PR TITLE
feat: selección de unidad (pieza/litro/kg) y cantidad por producto

### DIFF
--- a/app/(routes)/cart/components/cart-item.tsx
+++ b/app/(routes)/cart/components/cart-item.tsx
@@ -1,21 +1,17 @@
 import { X } from "lucide-react";
 
-import { useCart } from "@/hooks/use-cart";
-import { getPrimaryPricing } from "@/lib/pricing";
-import { ProductType } from "@/types/product";
+import { CartItem as CartItemType, useCart } from "@/hooks/use-cart";
+import { formatUnitQuantity } from "@/lib/units";
 import ProductCategories from "@/components/shared/product-categories";
 import ProductImageMiniature from "@/components/shared/product-image-miniature";
 
 interface CartItemProps {
-  product: ProductType;
+  product: CartItemType;
 }
 
 const CartItem = (props: CartItemProps) => {
   const { product } = props;
   const { removeItem } = useCart();
-
-  const { primaryPrice, primaryLabel, secondaryPrice } =
-    getPrimaryPricing(product);
 
   return (
     <li className="flex py-6 border-b">
@@ -28,23 +24,14 @@ const CartItem = (props: CartItemProps) => {
           <h2 className="text-base font-bold sm:text-lg">
             {product.productName}
           </h2>
-          {primaryPrice ? (
-            <div>
-              <p className="text-xs uppercase tracking-wide text-muted-foreground">
-                {primaryLabel}
-              </p>
-              <p className="font-display text-lg font-extrabold text-primary">
-                {primaryPrice}
-              </p>
-              {secondaryPrice && (
-                <p className="text-xs text-muted-foreground">
-                  Menudeo {secondaryPrice}
-                </p>
-              )}
-            </div>
-          ) : (
-            <p className="text-sm text-muted-foreground">Consultar precio</p>
-          )}
+          <div>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">
+              Cantidad
+            </p>
+            <p className="font-display text-lg font-extrabold text-primary">
+              {formatUnitQuantity(product.cartQuantity, product.cartUnit)}
+            </p>
+          </div>
           <div className="mt-1">
             <ProductCategories category={product.category} />
           </div>
@@ -52,7 +39,7 @@ const CartItem = (props: CartItemProps) => {
         <button
           type="button"
           aria-label={`Quitar ${product.productName} del pedido`}
-          onClick={() => removeItem(product.id)}
+          onClick={() => removeItem(product.id, product.cartUnit)}
           className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border bg-white shadow-md transition hover:scale-110"
         >
           <X size={18} />

--- a/app/(routes)/cart/page.tsx
+++ b/app/(routes)/cart/page.tsx
@@ -20,7 +20,12 @@ export default function Page() {
   const orderItems = mounted ? items : [];
 
   const sendOrder = () => {
-    openWhatsapp(buildOrderWhatsappUrl(orderItems, { baseUrl: getBaseUrl() }));
+    const orderLines = orderItems.map((item) => ({
+      ...item,
+      quantity: item.cartQuantity,
+      unidad: item.cartUnit,
+    }));
+    openWhatsapp(buildOrderWhatsappUrl(orderLines, { baseUrl: getBaseUrl() }));
   };
 
   return (
@@ -40,7 +45,7 @@ export default function Page() {
         <>
           <ul>
             {orderItems.map((item) => (
-              <CartItem key={item.id} product={item} />
+              <CartItem key={`${item.id}-${item.cartUnit ?? "sin-unidad"}`} product={item} />
             ))}
           </ul>
 

--- a/app/(routes)/product/[productSlug]/components/info-product.tsx
+++ b/app/(routes)/product/[productSlug]/components/info-product.tsx
@@ -1,13 +1,18 @@
 "use client";
 
-import { Heart, MessageCircle, Plus } from "lucide-react";
+import { useState } from "react";
+import { Heart, MessageCircle, Minus, Plus } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Separator } from "@/components/ui/separator";
 import { getPrimaryPricing } from "@/lib/pricing";
+import { getDefaultUnit, getProductUnits, unitLabel } from "@/lib/units";
 import { cn } from "@/lib/utils";
 import { buildWhatsappUrl, getBaseUrl, openWhatsapp } from "@/lib/whatsapp";
-import { ProductType } from "@/types/product";
+import { ProductType, SaleUnit } from "@/types/product";
 import { useLovedProducts } from "@/hooks/use-loved-products";
 import { useCart } from "@/hooks/use-cart";
 import { useMounted } from "@/hooks/use-mounted";
@@ -28,6 +33,27 @@ const InfoProduct = (props: InfoProductProps) => {
 
   const { primaryPrice, primaryLabel, secondaryPrice } =
     getPrimaryPricing(product);
+
+  // Unidades de venta del producto (puede no tener ninguna configurada).
+  const units = getProductUnits(product);
+  const hasUnits = units.length > 0;
+  const [selectedUnit, setSelectedUnit] = useState<SaleUnit | null>(() =>
+    getDefaultUnit(product)
+  );
+  const [quantity, setQuantity] = useState(1);
+
+  const handleQuantityChange = (value: string) => {
+    const parsed = parseInt(value, 10);
+    setQuantity(Number.isFinite(parsed) && parsed >= 1 ? parsed : 1);
+  };
+
+  const handleAddToCart = () => {
+    if (hasUnits) {
+      addItem(product, { unidad: selectedUnit, cantidad: quantity });
+    } else {
+      addItem(product);
+    }
+  };
 
   const handleWhatsapp = () => {
     openWhatsapp(buildWhatsappUrl(product, getBaseUrl()));
@@ -74,6 +100,78 @@ const InfoProduct = (props: InfoProductProps) => {
         )}
       </div>
 
+      {/* Selección de unidad y cantidad (solo si el producto tiene unidades) */}
+      {hasUnits && (
+        <div className="mb-6 flex flex-col gap-4">
+          <div>
+            <p className="mb-2 text-xs uppercase tracking-wide text-muted-foreground">
+              Unidad
+            </p>
+            <RadioGroup
+              value={selectedUnit ?? undefined}
+              onValueChange={(value) => setSelectedUnit(value as SaleUnit)}
+              className="flex flex-wrap gap-2"
+            >
+              {units.map((unit) => (
+                <Label
+                  key={unit}
+                  htmlFor={`unit-${unit}`}
+                  className={cn(
+                    "flex cursor-pointer items-center gap-2 rounded-md border px-3 py-2 text-sm capitalize transition",
+                    selectedUnit === unit
+                      ? "border-primary bg-primary/5"
+                      : "border-input hover:bg-muted"
+                  )}
+                >
+                  <RadioGroupItem id={`unit-${unit}`} value={unit} />
+                  {unitLabel(unit, true)}
+                </Label>
+              ))}
+            </RadioGroup>
+          </div>
+
+          <div>
+            <p className="mb-2 text-xs uppercase tracking-wide text-muted-foreground">
+              Cantidad
+            </p>
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                size="icon"
+                variant="outline"
+                onClick={() => setQuantity((q) => Math.max(1, q - 1))}
+                aria-label="Disminuir cantidad"
+              >
+                <Minus className="size-4" />
+              </Button>
+              <Input
+                type="number"
+                min={1}
+                inputMode="numeric"
+                value={quantity}
+                onChange={(event) => handleQuantityChange(event.target.value)}
+                className="w-20 text-center"
+                aria-label="Cantidad"
+              />
+              <Button
+                type="button"
+                size="icon"
+                variant="outline"
+                onClick={() => setQuantity((q) => q + 1)}
+                aria-label="Aumentar cantidad"
+              >
+                <Plus className="size-4" />
+              </Button>
+              {selectedUnit && (
+                <span className="text-sm text-muted-foreground">
+                  {unitLabel(selectedUnit, quantity !== 1)}
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* CTAs de conversión */}
       <div className="flex flex-col gap-3">
         <Button
@@ -88,7 +186,7 @@ const InfoProduct = (props: InfoProductProps) => {
           <Button
             type="button"
             variant="outline"
-            onClick={() => addItem(product)}
+            onClick={handleAddToCart}
             className="flex-1"
           >
             <Plus className="size-4" />

--- a/hooks/use-cart.tsx
+++ b/hooks/use-cart.tsx
@@ -2,31 +2,68 @@ import { create } from "zustand"
 import { persist, createJSONStorage } from "zustand/middleware"
 import { toast } from "sonner"
 
-import { ProductType } from "@/types/product"
+import { ProductType, SaleUnit } from "@/types/product"
+import { getDefaultUnit } from "@/lib/units"
+
+/** Ítem del pedido: el producto + la unidad y cantidad elegidas. */
+export type CartItem = ProductType & {
+    /** Unidad elegida (pieza/litro/kg); null si el producto no tiene unidades. */
+    cartUnit: SaleUnit | null
+    /** Cantidad solicitada en esa unidad (mínimo 1). */
+    cartQuantity: number
+}
+
+type AddItemOptions = {
+    unidad?: SaleUnit | null
+    cantidad?: number
+}
 
 interface CartStore {
-    items: ProductType[]
-    addItem: (data: ProductType) => void
-    removeItem: (id: number) => void
+    items: CartItem[]
+    addItem: (data: ProductType, options?: AddItemOptions) => void
+    removeItem: (id: number, unidad?: SaleUnit | null) => void
     removeAll: () => void
+}
+
+/** Normaliza la cantidad a un entero >= 1. */
+function normalizeQuantity(value?: number): number {
+    if (!value || !Number.isFinite(value) || value < 1) return 1
+    return Math.floor(value)
 }
 
 export const useCart = create(persist<CartStore>((set, get) => ({
     items: [],
-    addItem: (data: ProductType) => {
+    addItem: (data: ProductType, options?: AddItemOptions) => {
         const currentItems = get().items
-        const existingItem = currentItems.find((item) => item.id === data.id)
+        const unidad = options?.unidad ?? getDefaultUnit(data)
+        const cantidad = normalizeQuantity(options?.cantidad)
+
+        // Un mismo producto en distinta unidad son ítems separados; misma
+        // unidad suma cantidad.
+        const existingItem = currentItems.find(
+            (item) => item.id === data.id && item.cartUnit === unidad
+        )
 
         if (existingItem) {
-            return toast.error("El producto ya está en el carrito")
+            const updatedItems = currentItems.map((item) =>
+                item.id === data.id && item.cartUnit === unidad
+                    ? { ...item, cartQuantity: item.cartQuantity + cantidad }
+                    : item
+            )
+            set({ items: updatedItems })
+            return toast.success("Cantidad actualizada en tu pedido")
         }
 
-        set({ items: [...currentItems, data] })
+        set({
+            items: [...currentItems, { ...data, cartUnit: unidad, cartQuantity: cantidad }],
+        })
         toast.success("Producto agregado al carrito")
     },
-    removeItem: (id: number) => {
+    removeItem: (id: number, unidad?: SaleUnit | null) => {
         const currentItems = get().items
-        const updatedItems = currentItems.filter((item) => item.id !== id)
+        const updatedItems = currentItems.filter(
+            (item) => !(item.id === id && (unidad === undefined || item.cartUnit === unidad))
+        )
         set({ items: updatedItems })
         toast.success("Producto eliminado del carrito")
     },
@@ -36,5 +73,21 @@ export const useCart = create(persist<CartStore>((set, get) => ({
     }
 }), {
     name: "cart-storage",
-    storage: createJSONStorage(() => localStorage)
+    storage: createJSONStorage(() => localStorage),
+    // v1: el ítem pasó de ProductType a CartItem (unidad + cantidad).
+    version: 1,
+    migrate: (persisted, version) => {
+        const state = persisted as { items?: unknown[] } | null
+        if (state && version === 0) {
+            return {
+                ...state,
+                items: (state.items ?? []).map((item) => ({
+                    ...(item as object),
+                    cartUnit: null,
+                    cartQuantity: 1,
+                })),
+            } as unknown as CartStore
+        }
+        return persisted as CartStore
+    },
 }))

--- a/lib/data/strapi.ts
+++ b/lib/data/strapi.ts
@@ -39,6 +39,11 @@ function buildProductPopulate(includeDescription: boolean = false): URLSearchPar
   params.append('populate[category][fields][1]', 'slug');
   params.append('populate[category][fields][2]', 'id');
 
+  // Unidades de venta (componente repetible): necesarias para la unidad por
+  // defecto en cards/favoritos al agregar al pedido.
+  params.append('populate[unidades][fields][0]', 'unidad');
+  params.append('populate[unidades][fields][1]', 'predeterminada');
+
   // Only fetch needed product fields
   params.append('fields[0]', 'id');
   params.append('fields[1]', 'productName');
@@ -159,6 +164,10 @@ export async function getProductBySlug(slug: string): Promise<ProductType | null
   params.append('populate[category][fields][0]', 'categoryName');
   params.append('populate[category][fields][1]', 'slug');
   params.append('populate[category][fields][2]', 'id');
+
+  // Unidades de venta (componente repetible) para el selector del detalle.
+  params.append('populate[unidades][fields][0]', 'unidad');
+  params.append('populate[unidades][fields][1]', 'predeterminada');
 
   // Filter by slug
   params.append('filters[slug][$eq]', slug);

--- a/lib/units.ts
+++ b/lib/units.ts
@@ -1,0 +1,50 @@
+/**
+ * Helpers de unidad de venta (pieza/litro/kg).
+ * Centraliza el etiquetado de cantidad + unidad y la elección de la unidad
+ * por defecto, reutilizado por el detalle, el carrito y el mensaje de pedido.
+ */
+import type { ProductType, SaleUnit } from "@/types/product";
+
+/** Singular/plural por unidad para mostrar "1 pieza" / "3 piezas" / "2 litros". */
+const UNIT_LABELS: Record<SaleUnit, { one: string; many: string }> = {
+  pieza: { one: "pieza", many: "piezas" },
+  litro: { one: "litro", many: "litros" },
+  kg: { one: "kg", many: "kg" },
+};
+
+/** Orden de presentación estable de las unidades en el selector. */
+const UNIT_ORDER: SaleUnit[] = ["pieza", "litro", "kg"];
+
+/** Etiqueta legible de una unidad ("pieza", "litros", "kg"). */
+export function unitLabel(unit: SaleUnit, plural = false): string {
+  const label = UNIT_LABELS[unit];
+  return plural ? label.many : label.one;
+}
+
+/** Cantidad + unidad ya formateada, ej. "3 kg", "1 pieza"; sin unidad solo el número. */
+export function formatUnitQuantity(
+  quantity: number,
+  unit?: SaleUnit | null
+): string {
+  const qty = Number.isFinite(quantity) && quantity > 0 ? quantity : 1;
+  if (!unit) return `${qty}`;
+  return `${qty} ${unitLabel(unit, qty !== 1)}`;
+}
+
+/** Unidades del producto ordenadas; vacío si no tiene ninguna configurada. */
+export function getProductUnits(
+  product: Pick<ProductType, "unidades">
+): SaleUnit[] {
+  const unidades = product.unidades ?? [];
+  return UNIT_ORDER.filter((u) => unidades.some((item) => item.unidad === u));
+}
+
+/** Unidad por defecto: la marcada como `predeterminada`, o la primera disponible. */
+export function getDefaultUnit(
+  product: Pick<ProductType, "unidades">
+): SaleUnit | null {
+  const unidades = product.unidades ?? [];
+  if (unidades.length === 0) return null;
+  const preferred = unidades.find((u) => u.predeterminada) ?? unidades[0];
+  return preferred.unidad;
+}

--- a/lib/whatsapp.test.ts
+++ b/lib/whatsapp.test.ts
@@ -40,41 +40,44 @@ test("buildGeneralWhatsappUrl codifica un mensaje personalizado", () => {
 
 test("buildOrderWhatsappUrl apunta al teléfono configurado", () => {
   const url = buildOrderWhatsappUrl([
-    { productName: "Cloro", slug: "cloro", price_mayoreo: 100, price: 120 },
+    { productName: "Cloro", slug: "cloro" },
   ]);
   assert.ok(url.startsWith(`https://wa.me/${WHATSAPP_PHONE}?text=`));
 });
 
 test("buildOrderWhatsappUrl incluye los nombres de todos los ítems", () => {
   const url = buildOrderWhatsappUrl([
-    { productName: "Cloro", slug: "cloro", price_mayoreo: 100, price: 120 },
-    { productName: "Jabón líquido", slug: "jabon", price_mayoreo: 50, price: 60 },
+    { productName: "Cloro", slug: "cloro" },
+    { productName: "Jabón líquido", slug: "jabon" },
   ]);
   const text = decodeURIComponent(url);
   assert.ok(text.includes("Cloro"));
   assert.ok(text.includes("Jabón líquido"));
 });
 
-test("buildOrderWhatsappUrl usa el precio mayoreo cuando existe", () => {
+test("buildOrderWhatsappUrl muestra la cantidad y la unidad elegidas", () => {
   const url = buildOrderWhatsappUrl([
-    { productName: "Cloro", slug: "cloro", price_mayoreo: 100, price: 120 },
+    { productName: "Cloro", slug: "cloro", quantity: 3, unidad: "kg" },
+    { productName: "Aceite", slug: "aceite", quantity: 1, unidad: "litro" },
   ]);
   const text = decodeURIComponent(url);
-  assert.ok(text.includes("100"));
-  assert.ok(!text.includes("120"));
+  assert.ok(text.includes("3 kg"));
+  assert.ok(text.includes("1 litro"));
 });
 
-test("buildOrderWhatsappUrl cae a menudeo cuando falta el mayoreo", () => {
+test("buildOrderWhatsappUrl no incluye ningún precio en el mensaje", () => {
   const url = buildOrderWhatsappUrl([
-    { productName: "Cloro", slug: "cloro", price_mayoreo: null, price: 120 },
+    { productName: "Cloro", slug: "cloro", quantity: 2, unidad: "pieza" },
   ]);
   const text = decodeURIComponent(url);
-  assert.ok(text.includes("120"));
+  assert.ok(text.includes("2 piezas"));
+  // El precio quedó fuera del pedido por WhatsApp (se acuerda al contactar).
+  assert.ok(!/\$|MXN|EUR/.test(text));
 });
 
 test("buildOrderWhatsappUrl incluye los links cuando se pasa baseUrl", () => {
   const url = buildOrderWhatsappUrl(
-    [{ productName: "Cloro", slug: "cloro", price_mayoreo: 100, price: 120 }],
+    [{ productName: "Cloro", slug: "cloro" }],
     { baseUrl: "https://gamba.com" }
   );
   assert.ok(url.includes(encodeURIComponent("https://gamba.com/product/cloro")));
@@ -89,7 +92,7 @@ test("buildOrderWhatsappUrl con lista vacía devuelve una URL válida", () => {
 
 test("buildOrderWhatsappUrl codifica un intro personalizado", () => {
   const url = buildOrderWhatsappUrl(
-    [{ productName: "Cloro", slug: "cloro", price_mayoreo: 100 }],
+    [{ productName: "Cloro", slug: "cloro" }],
     { intro: "Estos son mis favoritos 👋" }
   );
   assert.ok(url.includes(encodeURIComponent("Estos son mis favoritos 👋")));

--- a/lib/whatsapp.ts
+++ b/lib/whatsapp.ts
@@ -3,7 +3,8 @@
  * WhatsApp es el canal de conversión oficial (Spec §4.4): este helper arma
  * el mensaje prellenado por producto, reutilizable desde card y detalle.
  */
-import { formatPrice } from "./formatPrice.ts";
+import { formatUnitQuantity } from "./units.ts";
+import type { SaleUnit } from "@/types/product";
 
 /** Número de destino (solo dígitos, formato wa.me). */
 export const WHATSAPP_PHONE = "524494056193";
@@ -63,11 +64,10 @@ export function buildGeneralWhatsappUrl(
 export type WhatsappOrderItem = {
   productName: string;
   slug: string;
-  /** Mayorista-first (RN-1): se muestra el mayoreo y, si falta, el menudeo. */
-  price_mayoreo?: number | null;
-  price?: number | null;
-  /** Reservado para un futuro modelo con cantidades (RF-14 "si aplica"). */
+  /** Cantidad solicitada (RF-14): se renderiza junto a la unidad si existe. */
   quantity?: number;
+  /** Unidad de venta elegida (pieza/litro/kg); null si el producto no la usa. */
+  unidad?: SaleUnit | null;
 };
 
 type OrderOptions = {
@@ -80,11 +80,15 @@ type OrderOptions = {
 const DEFAULT_ORDER_INTRO = "Hola, quiero hacer este pedido:";
 
 function buildOrderItemLine(item: WhatsappOrderItem, baseUrl?: string): string {
-  const priceValue = item.price_mayoreo ?? item.price;
-  const price = formatPrice(priceValue);
-  const qty = item.quantity && item.quantity > 1 ? ` x${item.quantity}` : "";
+  const quantity = item.quantity && item.quantity > 0 ? item.quantity : 1;
+  // Con unidad mostramos "3 kg"; sin unidad mantenemos el legado "x3".
+  const qty = item.unidad
+    ? ` (${formatUnitQuantity(quantity, item.unidad)})`
+    : quantity > 1
+      ? ` x${quantity}`
+      : "";
   const link = baseUrl ? ` ${baseUrl}/product/${item.slug}` : "";
-  return `• ${item.productName}${qty}${price ? ` — ${price}` : ""}${link}`;
+  return `• ${item.productName}${qty}${link}`;
 }
 
 /**

--- a/types/product.ts
+++ b/types/product.ts
@@ -6,6 +6,16 @@ export type ImageType = {
     url: string
 }
 
+/** Unidad de venta de un producto (componente repetible `unidades` en Strapi). */
+export type SaleUnit = 'pieza' | 'litro' | 'kg'
+
+export type ProductUnit = {
+    id: number
+    unidad: SaleUnit
+    /** Marca la unidad que sale seleccionada por defecto en el detalle. */
+    predeterminada?: boolean | null
+}
+
 export type ProductType = {
     id: number
     documentId?: string
@@ -20,6 +30,8 @@ export type ProductType = {
     price_mayoreo: number
     images?: ImageType[]
     category?: CategoryType
+    /** Unidades de venta disponibles para este producto (puede venir vacío). */
+    unidades?: ProductUnit[]
     createdAt?: string
     updatedAt?: string
 }


### PR DESCRIPTION
## Qué hace

Agrega la posibilidad de **elegir unidad de venta (pieza / litro / kg) y cantidad** por producto. Las unidades disponibles dependen de cada producto (se configuran en Strapi). En el carrito ya **no se muestra el precio**: solo la cantidad + unidad solicitada.

## Cambios

**Modelo / datos**
- `types/product.ts`: tipos `SaleUnit` / `ProductUnit` y campo `unidades` en `ProductType` (componente repetible de Strapi).
- `lib/units.ts` *(nuevo)*: helpers de etiqueta, cantidad+unidad (`"3 kg"`) y unidad por defecto.
- `lib/data/strapi.ts`: `populate[unidades]` en detalle y listados.
- `hooks/use-cart.tsx`: el ítem guarda `cartUnit` + `cartQuantity`; dedup por `id + unidad`; **migración** del carrito previo en localStorage.

**UI**
- Detalle de producto: selector de unidad (radio) + control de cantidad (− / input / +). Productos **sin** unidades se comportan igual que antes (sin selector).
- Carrito: muestra `Cantidad: 3 kg` en lugar del precio.

**Pedido por WhatsApp**
- La línea incluye cantidad + unidad (`• Cloro (3 kg)`), **sin precio**.

## Backend (ya desplegado)

El componente `producto.unidad` y el campo repetible `unidades` ya se agregaron al content-type Product y están en producción (repo `ecommerce-gamba-be`).

## Pendiente antes de que se vea en el sitio

⚠️ **Llenar las `unidades` de los productos** en el Content Manager de Strapi. Hoy los 87 productos las tienen vacías, por lo que el selector aún no aparece (comportamiento defensivo: sin unidades = flujo anterior).

## Verificación

- `tsc --noEmit` ✅
- `next lint` ✅
- `next build` ✅
- tests `30/30` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)